### PR TITLE
Serialisation script

### DIFF
--- a/database/README.md
+++ b/database/README.md
@@ -2,15 +2,24 @@
 
 Serwer bazy danych to PostgreSQL v.16, która została umieszczona w kontenerze Dockera w środowisku Alpine Linux. 
 
+Wymagania systemowe:
+- Docker Engine 
+- pqsl
+
+## Inicjalizacja
+
 Aby stworzyć bazę danych na maszynie należy uruchomić skrypt inicjujący: 
 ```
 sudo ./init.sh USERNAME PASSWORD
 ```
 Po krótkiej chwili zostanie uruchomiony kontener, ewentualnie pobrany obraz Dockera w przypadku jego braku w systemie operacyjnym. Następnie psql spróbuje nawiązać połączenie z bazą danych, pytając o wcześniej wprowadzone hasło, aby załadować plik inicjujący bazę danych. (UWAGA: W obecnej wersji skryptu opóźnienie na zaincjiowanie bazy danych może nie wystarczyć i system operacyjny odrzuci próbę połączenia. W tym przypadku należy ponownie uruchomić skrypt. Problem ten powinien zostać rozwiązany w przyszłości.)
 
-Wymagania systemowe:
-- Docker Engine 
-- pqsl
+## Serialziacja zasobów 
+
+Skrypt dump_json.sh pozwala na szybką zmianę wszystkich obiektów w bazie w pliki JSON, po jednym dla każdej encji. Pliki te następnie są pakowane w archiwum typu .zip, którego nazwa to "bestiarum-YYYY-MM-DD". Archiwum to następnie powinno zostać przeniesione przez użytkownika lub usunięte, szczególnie w przypadku wykonywania kilku serializacji w tym samym dniu. Uruchomienie skrypty odbywa się poprzez komendę:
+```
+./dump_json.sh USERNAME PASSWORD
+```
 
 ## UWAGI: 
 W obecnej wersji nie występuje poprawna inicjalizacja volume służącego do stałego przechowywania danych z bazy. Rozwiązanie tego problemu powinno być priorytetem przed rozpoczęciem korzystania z bazy i zapełniania jej danymi.  

--- a/database/README.md
+++ b/database/README.md
@@ -2,6 +2,8 @@
 
 Serwer bazy danych to PostgreSQL v.16, która została umieszczona w kontenerze Dockera w środowisku Alpine Linux. 
 
+W środowisku hostowanego serwera dostępne jest ograniczona liczba portów dla serwera, więc na potrzeby zewnętrznego dostępu do bazy danych, wybrano port `20960` dla serwera PostgreSQL. Może to zostać zmienione w przyszłości, gdy zarządzaniem bazą danych będzie zajmować się API. 
+
 Wymagania systemowe:
 - Docker Engine 
 - pqsl

--- a/database/dump_json.sh
+++ b/database/dump_json.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# set -x
+
+USERNAME=${1:-0}
+PASSWORD=${2:-0}
+
+URLI="postgresql://${USERNAME}:${PASSWORD}@0.0.0.0:20960/bestiarium"
+FLAGS="-t -A"
+
+# Step 1 -> Get tables names 
+QUERY_TABLES_NAMES="SELECT table_name FROM information_schema.tables WHERE table_schema='public'"
+TABLES_NAMES=$(psql ${URLI} ${FLAGS} -c "${QUERY_TABLES_NAMES}")
+
+# Step 2 -> Temporary directory for json files
+mkdir temporary_dir
+
+# Step 3 -> Dump every table to a JSON file 
+for TABLE in ${TABLES_NAMES}; do
+  QUERY_JSON_DUMP="select json_agg(t) from (select * from ${TABLE}) t"
+  psql ${URLI} ${FLAGS} -c "${QUERY_JSON_DUMP}" > "temporary_dir/${TABLE}.json"
+done
+
+# Step 4 -> Zip all files into archive
+DATE=$(date +%Y-%m-%d)
+zip -q -r "bestiarum_${DATE}.zip" temporary_dir/*
+
+rm -r temporary_dir

--- a/database/init.sh
+++ b/database/init.sh
@@ -8,7 +8,7 @@ PG_PORT=20960 # Required for the hosted server
 
 docker pull ${POSTGRES_IMAGE} 
 docker run --name=postgres-bestiarium \
-           --mount source=posrgres_data,target=/var/lib/postgreqsl/data \ # TODO Should work, it doesn't - needs fixint!
+           --mount source=posrgres_data,target=/var/lib/postgreqsl/data \
            -p ${PG_PORT}:5432 \
            -e POSTGRES_DB=bestiarium \
            -e POSTGRES_USER=${USERNAME} \


### PR DESCRIPTION
Closes #3 

Plik dump_json.sh zawiera skrypt do serialziacji bazy danych o nazwie bestiarium pod portem 20960 i zapakowaniu plików do archiwum, przy czym wymaga podania nazwy użytkownika i hasła